### PR TITLE
Add functionality to extract teams for each repository

### DIFF
--- a/05-list-repos-and-teams.sh
+++ b/05-list-repos-and-teams.sh
@@ -3,13 +3,14 @@
 ##
 # Author: Enderson Menezes
 # Created: 2024-06-15
-# Description: This script 
-# Usage: bash 05-list-repos-and-teams.sh <organization>
+# Description: This script extracts data from a specified repository and returns a CSV with all teams.
+# Usage: bash 05-list-repos-and-teams.sh <organization> <repository>
 ##
 
 organization=$1
-if [ -z $organization ]; then
-  echo "Please provide the organization name"
+repository=$2
+if [ -z $organization ] || [ -z $repository ]; then
+  echo "Please provide the organization name and repository name"
   exit 1
 fi
 
@@ -32,3 +33,13 @@ gh api \
 
 # Create CSV file: team_name, team_id
 jq -r '.[] | [.name, .id] | @csv' teams_$organization.json > teams_$organization.csv
+
+# List teams for the specified repository
+gh api \
+  -H "Accept: application/vnd.github+json" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  /repos/$organization/$repository/teams \
+  --paginate > repo_teams_$repository.json
+
+# Create combined CSV file: repo_name, repo_url, repo_maintainer, team_name, team_id
+jq -r --arg repo_name "$repository" --arg repo_url "$(jq -r --arg repo_name "$repository" '.[] | select(.name == $repo_name) | .html_url' repos_$organization.json)" --arg repo_maintainer "$(jq -r --arg repo_name "$repository" '.[] | select(.name == $repo_name) | .owner.login' repos_$organization.json)" '.[] | [$repo_name, $repo_url, $repo_maintainer, .name, .id] | @csv' repo_teams_$repository.json > combined_$repository.csv

--- a/README.md
+++ b/README.md
@@ -26,6 +26,6 @@ All scripts have a common features:
 - `02-archive-repos.sh` - Archive a set of repos from 02-archive-repos.csv
 - `03-force-code-owners-all-teams.sh` - Migrate to: https://github.com/endersonmenezes/codeowners-superpowers
 - `04-app-token.sh` - Generate a token for a set of apps from 04-app-token.csv
-- `05-list-repos-and-teams.sh` - List all repos and teams from Organization.
+- `05-list-repos-and-teams.sh` - Extracts data from a specified repository and returns a CSV with all teams.
 - `06-analyze-logs.py` - Transform JSONL to CSV for logging analysis.
 - `07-delete-teams.sh` - Delete a set of teams from 07-delete-teams.csv


### PR DESCRIPTION
Add functionality to extract data from a specified repository and return a CSV with all teams.

* **05-list-repos-and-teams.sh**
  - Modify the script to accept both organization and repository as input parameters.
  - Add functionality to list teams for the specified repository.
  - Generate a combined CSV file with columns: `repo_name`, `repo_url`, `repo_maintainer`, `team_name`, `team_id`.
  - Update the script usage description to reflect the new functionality.

* **README.md**
  - Update the description of `05-list-repos-and-teams.sh` to reflect the new functionality.
  - Mention that the script now extracts data from a specified repository and returns a CSV with all teams.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/endersonmenezes/github-scripts?shareId=9db8e273-dea7-4270-8cef-1e069cbda600).